### PR TITLE
add div to ytplayer for proper scaling

### DIFF
--- a/layouts/shortcodes/hide-vid-show-text.html
+++ b/layouts/shortcodes/hide-vid-show-text.html
@@ -4,12 +4,13 @@
         align-items: center;
     }
 </style>
-<iframe class="youtube-player" type="text/html" width="640" height="385"
-    src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
-</iframe>
-
+<div class="ytplayer-container">
+    <iframe class="youtube-player" type="text/html"
+        src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
+    </iframe>
+</div>
 <button _="on click queue all
-    transition .youtube-player's opacity to 0 then hide .youtube-player
+    transition .ytplayer-container's opacity to 0 then hide .ytplayer-container
     hide me
     show .a2_index-story with display
     transition .a2_index-story's opacity to 100

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -49,3 +49,17 @@ a.page__logo-top-inner:active {
     margin: 0;
     padding: 0.25rem 0;
 }
+
+.ytplayer-container{
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+}
+.youtube-player {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
closes #3 

The youtube player iframe section needed a supporting <div> tag around it so that it scales properly when viewed on mobile or a really skinny window.  The shortcode now operates on the new div class instead of the iframe class.